### PR TITLE
Adds email confirmation and forgot password functionality with mailcatcher + devise 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,8 @@ gem 'cancancan', '~> 1.10'
 gem 'delayed_job_active_record'
 gem 'carrierwave', github: 'carrierwaveuploader/carrierwave' # for enabling multiple uploads
 gem 'mini_magick'
+gem 'mailcatcher'
+
 
 group :development, :test do
   gem 'byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,6 +68,7 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.10.0)
+    daemons (1.2.3)
     debug_inspector (0.0.2)
     delayed_job (4.1.1)
       activesupport (>= 3.0, < 5.0)
@@ -82,6 +83,7 @@ GEM
       thread_safe (~> 0.1)
       warden (~> 1.2.3)
     erubis (2.7.0)
+    eventmachine (1.0.5)
     execjs (2.6.0)
     faker (1.6.1)
       i18n (~> 0.5)
@@ -108,6 +110,14 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
+    mailcatcher (0.6.1)
+      activesupport (>= 4.0.0, < 5)
+      eventmachine (~> 1.0.0, <= 1.0.5)
+      mail (~> 2.3)
+      sinatra (~> 1.2)
+      skinny (~> 0.2.3)
+      sqlite3 (~> 1.3)
+      thin (~> 1.5.0)
     mime-types (2.99)
     mini_magick (4.3.6)
     mini_portile (0.6.2)
@@ -120,6 +130,8 @@ GEM
     quiet_assets (1.1.0)
       railties (>= 3.1, < 5.0)
     rack (1.6.4)
+    rack-protection (1.5.3)
+      rack
     rack-test (0.6.3)
       rack (>= 1.0)
     rails (4.2.4)
@@ -160,6 +172,13 @@ GEM
     sdoc (0.4.1)
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
+    sinatra (1.4.6)
+      rack (~> 1.4)
+      rack-protection (~> 1.4)
+      tilt (>= 1.3, < 3)
+    skinny (0.2.3)
+      eventmachine (~> 1.0.0)
+      thin (~> 1.5.0)
     spoon (0.0.4)
       ffi
     spring (1.4.4)
@@ -169,6 +188,11 @@ GEM
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       sprockets (>= 2.8, < 4.0)
+    sqlite3 (1.3.11)
+    thin (1.5.1)
+      daemons (>= 1.0.9)
+      eventmachine (>= 0.12.6)
+      rack (>= 1.0.0)
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (2.0.1)
@@ -205,6 +229,7 @@ DEPENDENCIES
   jbuilder (~> 2.0)
   jquery-rails
   letter_opener
+  mailcatcher
   mini_magick
   pg
   quiet_assets

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,7 @@
 class User < ActiveRecord::Base
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
-  devise :database_authenticatable, :registerable,
+  devise :database_authenticatable, :registerable, :confirmable,
          :recoverable, :rememberable, :trackable, :validatable
 
   validates :first_name, presence: true

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -40,4 +40,7 @@ Rails.application.configure do
   # config.action_view.raise_on_missing_translations = true
 
   config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {:address => 'localhost', :port => 1025}
+  
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -12,7 +12,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = 'please-change-me-at-config-initializers-devise@example.com'
+  config.mailer_sender = 'hello@drillr.ca'
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'

--- a/db/migrate/20151128202802_add_confirmable_to_devise.rb
+++ b/db/migrate/20151128202802_add_confirmable_to_devise.rb
@@ -1,0 +1,23 @@
+class AddConfirmableToDevise < ActiveRecord::Migration
+  def up
+   add_column :users, :confirmation_token, :string
+   add_column :users, :confirmed_at, :datetime
+   add_column :users, :confirmation_sent_at, :datetime
+   add_column :users, :unconfirmed_email, :string # Only if using reconfirmable
+   add_index  :users, :confirmation_token, unique: true
+   # User.reset_column_information # Need for some types of updates, but not for update_all.
+   # To avoid a short time window between running the migration and updating all existing
+   # users as confirmed, do the following
+   execute("UPDATE users SET confirmed_at = NOW()")
+   # All existing user accounts should be able to log in after this.
+   # Remind: Rails using SQLite as default. And SQLite has no such function :NOW.
+   # Use :date('now') instead of :NOW when using SQLite.
+   # => execute("UPDATE users SET confirmed_at = date('now')")
+   # Or => User.all.update_all confirmed_at: Time.now
+ end
+
+ def down
+   remove_columns :users, :confirmation_token, :confirmed_at, :confirmation_sent_at
+   remove_columns :users, :unconfirmed_email # Only if using reconfirmable
+ end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151128183017) do
+ActiveRecord::Schema.define(version: 20151128202802) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -113,8 +113,13 @@ ActiveRecord::Schema.define(version: 20151128183017) do
     t.string   "username"
     t.integer  "points"
     t.boolean  "is_admin"
+    t.string   "confirmation_token"
+    t.datetime "confirmed_at"
+    t.datetime "confirmation_sent_at"
+    t.string   "unconfirmed_email"
   end
 
+  add_index "users", ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true, using: :btree
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree
   add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
 


### PR DESCRIPTION
Reference:
https://github.com/plataformatec/devise/wiki/How-To:-Add-:confirmable-to-Users

gem 'mailcatcher'

config>environments>development.rb:
//below the localhost:3000
config.action_mailer.delivery_method = :smtp
config.action_mailer.smtp_settings = {:address => 'localhost', :port => 1025}

user.rb:
add :confirmable

config>initializers>devise.rb:
config.mailer_sender = 'hello@drillr.ca'

Generate migration:
rails g migration add_confirmable_to_devise

in the migration file
class AddConfirmableToDevise < ActiveRecord::Migration
  # Note: You can't use change, as User.update_all will fail in the down migration
  def up
    add_column :users, :confirmation_token, :string
    add_column :users, :confirmed_at, :datetime
    add_column :users, :confirmation_sent_at, :datetime
    add_column :users, :unconfirmed_email, :string # Only if using reconfirmable
    add_index :users, :confirmation_token, unique: true

```
execute("UPDATE users SET confirmed_at = NOW()")
```

  end

  def down
     remove_columns :users, :confirmation_token, :confirmed_at, :confirmation_sent_at
     remove_columns :users, :unconfirmed_email # Only if using reconfirmable
  end
end

Migrate:

bin/rake db:migrate

Start Mailcatcher:
mailcatcher

To test:
//UNCOMMENT VALIDATIONS FIRST NAME AND LAST NAME in USER.rb

Visit http://127.0.0.1:1080/ to view email.
